### PR TITLE
Update CI to use different os and java versions

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -9,11 +9,19 @@ on:
 jobs:
   build:
     name: "Build"
-    runs-on: "ubuntu-latest"
+    runs-on: ${{ matrix.os }}
+    
+    strategy:
+      matrix:
+        java-version: [17, 21]
+        os: ["ubuntu-latest", "windows-latest"]
 
     steps: 
       - name: "Clone repository"
         uses: actions/checkout@v4
+        with:
+          distribution: "oracle"
+          java-version: ${{ matrix.java-version }}
       
       - name: "Build project"
         run: ./gradlew build

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -2,7 +2,7 @@ name: "Java"
 
 on: 
   pull_request:
-    braches:
+    branches:
       - main
   workflow_dispatch:
 

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           distribution: "oracle"
           java-version: ${{ matrix.java-version }}
+          cache: "gradle"
       
       - name: "Build project"
         run: ./gradlew build


### PR DESCRIPTION
- CI now runs on Java 17 and 21.
- Runs each Java version on the latest windows and ubuntu.
- Adds caching for our dependencies.