### PR TITLE
Update CI to use different OS and Java versions

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -2,7 +2,7 @@ name: "Java"
 
 on: 
   pull_request:
-    braches:
+    branches:
       - main
   workflow_dispatch:
 

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -9,11 +9,21 @@ on:
 jobs:
   build:
     name: "Build"
-    runs-on: "ubuntu-latest"
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        java-version: [17, 21]
+        os: ["ubuntu-latest", "windows-latest"]
 
     steps: 
       - name: "Clone repository"
         uses: actions/checkout@v4
-      
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "oracle"
+          java-version: ${{ matrix.java-version }}
+
       - name: "Build project"
         run: ./gradlew build

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           distribution: "oracle"
           java-version: ${{ matrix.java-version }}
+          cache: "gradle"
 
       - name: "Build project"
-        run: ./gradlew build
+        run: ./gradlew --no-daemon build


### PR DESCRIPTION
- CI now runs on Java 17 and 21
- CI now runs on windows and ubuntu for each Java version
- Add dependency caching