### PR TITLE
Set up postgres database using docker

### DIFF
--- a/databaseSSH.sql
+++ b/databaseSSH.sql
@@ -1,0 +1,4 @@
+CREATE TABLE tenants (
+    tenant_id integer,
+    tenant_name varchar(255)
+)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 # Use postgres/example user/password credentials
-version: '3.9'
 
 services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
     #      size: 134217728 # 128*2^20 bytes = 128Mb
     environment:
       POSTGRES_PASSWORD: example
+    volumes: 
+      - ./databaseSSH.sql:/docker-entrypoint-initdb.d/databaseSSH.sql
 
   adminer:
     image: adminer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+# Use postgres/example user/password credentials
+version: '3.9'
+
+services:
+
+  db:
+    image: postgres
+    restart: always
+    # set shared memory limit when using docker-compose
+    shm_size: 128mb
+    # or set shared memory limit when deploy via swarm stack
+    #volumes:
+    #  - type: tmpfs
+    #    target: /dev/shm
+    #    tmpfs:
+    #      size: 134217728 # 128*2^20 bytes = 128Mb
+    environment:
+      POSTGRES_PASSWORD: example
+
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 8080:8080


### PR DESCRIPTION
Add docker-compose.yml to allow for easy set up of the database across any environment.

In brief do: docker compose -f docker-compose.yml -d 
in the terminal
This will run the container with postgres on port 8080. 
You can stop docker (and database) running by doing: docker compose down