### PR TITLE
Fix build artifacts for CI

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -30,8 +30,11 @@ jobs:
       - name: "Build project"
         run: ./gradlew --no-daemon build
 
+      - name: "Produce distribution"
+        run: ./gradlew distZip
+
       - name: "Upload build artifacts"
         uses: actions/upload-artifact@v4
         with:
           name: ssh-java-${{ matrix.java-version }}-${{ matrix.os }}
-          path: app/build/libs
+          path: app/build/distributions/app.zip


### PR DESCRIPTION
Add produce distribution step to create a zip file so we can get the expected build artifact.
Updated the path of the build artifact accordingly.