### PR TITLE
Add test coverage check in our CI

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -41,6 +41,8 @@ jobs:
       - name: "Ingredients test"
         run: ./gradlew test --tests org.example.TenantIngredientsTest
         
+      - name: "Test coverage"
+        run: ./gradlew jacocoTestCoverageVerification
 
       - name: "Produce distribution"
         run: ./gradlew distZip

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -32,20 +32,23 @@ jobs:
       - name: "Build project"
         run: ./gradlew app:compileJava
         
-      - name: "Basic tests"
-        run: ./gradlew test --tests org.example.DatabaseTest --tests org.example.LoadRecipeTest
-        
-      - name: "Quality test"
-        run: ./gradlew test --tests org.example.IngredientsTest
-
-      - name: "Ingredients test"
-        run: ./gradlew test --tests org.example.TenantIngredientsTest
+      - name: "Tests"
+        run: ./gradlew test
         
       - name: "Test coverage"
         run: ./gradlew jacocoTestCoverageVerification
 
+      - name: "Generate test coverage report"
+        run: ./gradlew jacocoTestReport
+
       - name: "Produce distribution"
         run: ./gradlew distZip
+
+      - name: "Upload test coverage artifact"
+        uses: actions/upload-artfact@v4
+        with:
+          name: code-coverage-java-${{ matrix.java-version }}
+          path: app/build/reports/jacoco/test/html/index.html
 
       - name: "Upload build artifacts"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -45,7 +45,7 @@ jobs:
         run: ./gradlew distZip
 
       - name: "Upload test coverage artifact"
-        uses: actions/upload-artfact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-java-${{ matrix.java-version }}
           path: app/build/reports/jacoco/test/html/index.html

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,3 +47,13 @@ tasks.named<Test>("test") {
     // Use JUnit Platform for unit tests.
     useJUnitPlatform()
 }
+
+tasks.jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = "0.40".toBigDecimal()
+            }
+        }
+    }
+}


### PR DESCRIPTION
For the checks to pass we must have at least 40% code coverage, this is done via a new task in biuld.gradle.kts using jacoco.