### PR TITLE
Add test coverage check to our CI

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -41,6 +41,8 @@ jobs:
       - name: "Ingredients test"
         run: ./gradlew test --tests org.example.TenantIngredientsTest
         
+      - name: "Test coverage"
+        run: ./gradlew jacocoTestCoverageVerification
 
       - name: "Produce distribution"
         run: ./gradlew distZip

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -32,18 +32,33 @@ jobs:
       - name: "Build project"
         run: ./gradlew app:compileJava
         
-      - name: "Basic tests"
-        run: ./gradlew test --tests org.example.DatabaseTest --tests org.example.LoadRecipeTest
-        
-      - name: "Quality test"
-        run: ./gradlew test --tests org.example.IngredientsTest
-
-      - name: "Ingredients test"
-        run: ./gradlew test --tests org.example.TenantIngredientsTest
+      - name: "Tests"
+        run: ./gradlew test
         
       - name: "Test coverage"
         run: ./gradlew jacocoTestCoverageVerification
 
+      -  name: JaCoCo Code Coverage Report
+         id: jacoco_reporter
+         uses: PavanMudigonda/jacoco-reporter@v5.0
+         with:
+          coverage_results_path: app/build/reports/jacoco/test/jacocoTestReport.xml
+          coverage_report_name: Coverage-java--${{ matrix.java-version }}
+          coverage_report_title: JaCoCo
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          skip_check_run: false
+          publish_only_summary: false
+
+      # Publish Coverage Job Summary
+      - name: Add Jacocoo report to workflow run summary
+        run: |
+          echo "| Outcome | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
+          echo "| Code Coverage % | ${{ steps.jacoco_reporter.outputs.coverage_percentage }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| ✔️ Number of Lines Covered | ${{ steps.jacoco_reporter.outputs.covered_lines }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| ❌ Number of Lines Missed | ${{ steps.jacoco_reporter.outputs.missed_lines }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Total Number of Lines | ${{ steps.jacoco_reporter.outputs.total_lines }} |" >> $GITHUB_STEP_SUMMARY
+      
       - name: "Produce distribution"
         run: ./gradlew distZip
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,3 +47,13 @@ tasks.named<Test>("test") {
     // Use JUnit Platform for unit tests.
     useJUnitPlatform()
 }
+
+tasks.jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = "0.40".toBigDecimal()
+            }
+        }
+    }
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,14 @@ application {
 tasks.named<Test>("test") {
     // Use JUnit Platform for unit tests.
     useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    reports {
+        xml.required = true
+        html.required = true
+    }
 }
 
 tasks.jacocoTestCoverageVerification {


### PR DESCRIPTION
For the checks to pass we must have at least 40% code coverage, this is done via a new task in biuld.gradle.kts using jacoco.